### PR TITLE
fix: lint-staged warning for v10

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+package.json
+node_modules
+dist

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "@angular-devkit/core": "^11.0.2",
     "@angular-devkit/schematics": "^11.0.2",
     "@types/node": "^14.14.10",
+    "husky": "^4.3.0",
+    "lint-staged": "^10.5.2",
+    "prettier": "^2.2.1",
     "rxjs": "^6.6.3",
     "typescript": "^4.1.2"
   },
@@ -61,5 +64,13 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{js,json,css,scss,less,md,ts,html,component.html}": "prettier --write"
   }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	printWidth: 100,
+	tabWidth: 2,
+	useTabs: true,
+	semi: true,
+	singleQuote: true,
+	trailingComma: 'es5',
+};

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,8 +1,8 @@
 module.exports = {
-	printWidth: 100,
-	tabWidth: 2,
-	useTabs: true,
-	semi: true,
-	singleQuote: true,
-	trailingComma: 'es5',
+  printWidth: 100,
+  tabWidth: 2,
+  useTabs: false,
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'es5',
 };

--- a/src/prettier/index.ts
+++ b/src/prettier/index.ts
@@ -1,190 +1,184 @@
 import {
-  Rule,
-  SchematicContext,
-  Tree,
-  chain,
-  apply,
-  url,
-  template,
-  move,
-  mergeWith,
+	Rule,
+	SchematicContext,
+	Tree,
+	chain,
+	apply,
+	url,
+	template,
+	move,
+	mergeWith,
 } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { Observable, of } from 'rxjs';
 import { map, concatMap, filter } from 'rxjs/operators';
 
-import {
-  PrettierOptions,
-  getDefaultOptions,
-  PrettierSettings,
-} from '../utility/prettier-util';
+import { PrettierOptions, getDefaultOptions, PrettierSettings } from '../utility/prettier-util';
 import { addPackageJsonDependency, NodeDependencyType } from '../utility/dependencies';
 import {
-  getLatestNodeVersion,
-  NpmRegistryPackage,
-  getFileAsJson,
-  addPropertyToPackageJson,
+	getLatestNodeVersion,
+	NpmRegistryPackage,
+	getFileAsJson,
+	addPropertyToPackageJson,
 } from '../utility/util';
 import { JsonObject } from '@angular-devkit/core';
 
-export default function(options: PrettierOptions): Rule {
-  return (tree: Tree, context: SchematicContext) => {
-    const cliOptions = getDefaultOptions(context, options, new PrettierSettings());
+export default function (options: PrettierOptions): Rule {
+	return (tree: Tree, context: SchematicContext) => {
+		const cliOptions = getDefaultOptions(context, options, new PrettierSettings());
 
-    return chain([
-      addDependencies(cliOptions),
-      addPrettierFiles(cliOptions),
-      installPackages(),
-      modifyTsLint(),
-      updateEditorConfig(cliOptions),
-      addLintStagedConfig(cliOptions),
-      addScripts(cliOptions),
-    ])(tree, context);
-  };
+		return chain([
+			addDependencies(cliOptions),
+			addPrettierFiles(cliOptions),
+			installPackages(),
+			modifyTsLint(),
+			updateEditorConfig(cliOptions),
+			addLintStagedConfig(cliOptions),
+			addScripts(cliOptions),
+		])(tree, context);
+	};
 }
 
 const prettierCommand = 'prettier --write';
 const tslintConfigPackage = 'tslint-config-prettier';
 
 function addDependencies(options: PrettierOptions): Rule {
-  return (tree: Tree): Observable<Tree> => {
-    const lintStagedDep = ['lint-staged', 'husky'];
+	return (tree: Tree): Observable<Tree> => {
+		const lintStagedDep = ['lint-staged', 'husky'];
 
-    return of('prettier', 'lint-staged', 'husky', tslintConfigPackage).pipe(
-      filter((pkg) => {
-        if (options.lintStaged === false) {
-          // remove lint-staged deps
-          return !lintStagedDep.some((p) => p === pkg);
-        }
-        return true;
-      }),
-      concatMap((pkg: string) => getLatestNodeVersion(pkg)),
-      map((packageFromRegistry: NpmRegistryPackage) => {
-        const { name, version } = packageFromRegistry;
+		return of('prettier', 'lint-staged', 'husky', tslintConfigPackage).pipe(
+			filter((pkg) => {
+				if (options.lintStaged === false) {
+					// remove lint-staged deps
+					return !lintStagedDep.some((p) => p === pkg);
+				}
+				return true;
+			}),
+			concatMap((pkg: string) => getLatestNodeVersion(pkg)),
+			map((packageFromRegistry: NpmRegistryPackage) => {
+				const { name, version } = packageFromRegistry;
 
-        addPackageJsonDependency(tree, { type: NodeDependencyType.Dev, name, version });
+				addPackageJsonDependency(tree, { type: NodeDependencyType.Dev, name, version });
 
-        return tree;
-      })
-    );
-  };
+				return tree;
+			})
+		);
+	};
 }
 
 function installPackages(): Rule {
-  return (tree: Tree, context: SchematicContext): Tree => {
-    return context.addTask(new NodePackageInstallTask()) && tree;
-  };
+	return (tree: Tree, context: SchematicContext): Tree => {
+		return context.addTask(new NodePackageInstallTask()) && tree;
+	};
 }
 
 function addPrettierFiles(prettierOptions: PrettierOptions): Rule {
-  return (tree: Tree, context: SchematicContext) => {
-    const templateSource = apply(url('./files'), [
-      template({
-        ...prettierOptions,
-      }),
-      move('./'),
-    ]);
+	return (tree: Tree, context: SchematicContext) => {
+		const templateSource = apply(url('./files'), [
+			template({
+				...prettierOptions,
+			}),
+			move('./'),
+		]);
 
-    return chain([mergeWith(templateSource)])(tree, context);
-  };
+		return chain([mergeWith(templateSource)])(tree, context);
+	};
 }
 
 function modifyTsLint(): Rule {
-  return (tree: Tree, context: SchematicContext) => {
-    const tslintPath = 'tslint.json';
-    if (tree.exists(tslintPath)) {
-      const tslint = getFileAsJson(tree, tslintPath) as JsonObject;
+	return (tree: Tree, context: SchematicContext) => {
+		const tslintPath = 'tslint.json';
+		if (tree.exists(tslintPath)) {
+			const tslint = getFileAsJson(tree, tslintPath) as JsonObject;
 
-      if (!tslint) return tree;
+			if (!tslint) return tree;
 
-      if (Array.isArray(tslint.extends)) {
-        // should be added last https://github.com/prettier/tslint-config-prettier
-        tslint.extends.push(tslintConfigPackage);
-      } else if (typeof tslint.extends === 'string') {
-        tslint.extends = [tslint.extends, tslintConfigPackage];
-      } else {
-        tslint.extends = tslintConfigPackage;
-      }
+			if (Array.isArray(tslint.extends)) {
+				// should be added last https://github.com/prettier/tslint-config-prettier
+				tslint.extends.push(tslintConfigPackage);
+			} else if (typeof tslint.extends === 'string') {
+				tslint.extends = [tslint.extends, tslintConfigPackage];
+			} else {
+				tslint.extends = tslintConfigPackage;
+			}
 
-      tree.overwrite(tslintPath, JSON.stringify(tslint, null, 2));
-    } else {
-      context.logger.info(
-        `unable to locate tslint file at ${tslintPath}, conflicting styles may exists`
-      );
-    }
+			tree.overwrite(tslintPath, JSON.stringify(tslint, null, 2));
+		} else {
+			context.logger.info(
+				`unable to locate tslint file at ${tslintPath}, conflicting styles may exists`
+			);
+		}
 
-    return tree;
-  };
+		return tree;
+	};
 }
 
 function updateEditorConfig(options: PrettierOptions): Rule {
-  return (tree: Tree, context: SchematicContext) => {
-    const editorConfigPath = '.editorconfig';
-    const rule = 'indent_size';
+	return (tree: Tree, context: SchematicContext) => {
+		const editorConfigPath = '.editorconfig';
+		const rule = 'indent_size';
 
-    if (tree.exists(editorConfigPath)) {
-      // editorconfig exists on host
-      const editorConfigBuffer = tree.read(editorConfigPath);
+		if (tree.exists(editorConfigPath)) {
+			// editorconfig exists on host
+			const editorConfigBuffer = tree.read(editorConfigPath);
 
-      if (editorConfigBuffer === null) {
-        // unable to read editorconfig
-        context.logger.info(
-          `Could not modify .editorconfig at ${editorConfigPath}. Update ${rule} to match tabWidth: ${
-            options.tabWidth
-          }.`
-        );
-      } else {
-        // editorconfig parsed, modify
-        const ecBuffer = editorConfigBuffer.toString();
+			if (editorConfigBuffer === null) {
+				// unable to read editorconfig
+				context.logger.info(
+					`Could not modify .editorconfig at ${editorConfigPath}. Update ${rule} to match tabWidth: ${options.tabWidth}.`
+				);
+			} else {
+				// editorconfig parsed, modify
+				const ecBuffer = editorConfigBuffer.toString();
 
-        if (ecBuffer.includes(rule)) {
-          const modifiedEditorConfig = ecBuffer
-            .split('\n')
-            .map((line) => {
-              if (line.includes(rule)) {
-                return `indent_size = ${options.tabWidth}`;
-              } else {
-                return line;
-              }
-            })
-            .join('\n');
+				if (ecBuffer.includes(rule)) {
+					const modifiedEditorConfig = ecBuffer
+						.split('\n')
+						.map((line) => {
+							if (line.includes(rule)) {
+								return `indent_size = ${options.tabWidth}`;
+							} else {
+								return line;
+							}
+						})
+						.join('\n');
 
-          tree.overwrite(editorConfigPath, modifiedEditorConfig);
-        }
-      }
-    }
-    return tree;
-  };
+					tree.overwrite(editorConfigPath, modifiedEditorConfig);
+				}
+			}
+		}
+		return tree;
+	};
 }
 
 function addLintStagedConfig(options: PrettierOptions) {
-  return (tree: Tree, context: SchematicContext) => {
-    if (options.lintStaged === true) {
-      addPropertyToPackageJson(tree, context, 'husky', {
-        hooks: { 'pre-commit': 'lint-staged' },
-      });
+	return (tree: Tree, context: SchematicContext) => {
+		if (options.lintStaged === true) {
+			addPropertyToPackageJson(tree, context, 'husky', {
+				hooks: { 'pre-commit': 'lint-staged' },
+			});
 
-      addPropertyToPackageJson(tree, context, 'lint-staged', {
-        [`*.{${getFileTypes(options.formatAllAngularFiles)}}`]: [prettierCommand, 'git add'],
-      });
-    }
-    return tree;
-  };
+			addPropertyToPackageJson(tree, context, 'lint-staged', {
+				[`*.{${getFileTypes(options.formatAllAngularFiles)}}`]: [prettierCommand],
+			});
+		}
+		return tree;
+	};
 }
 
 function addScripts(options: PrettierOptions) {
-  return (tree: Tree, context: SchematicContext) => {
-    addPropertyToPackageJson(tree, context, 'scripts', {
-      // run against all typescript files
-      // prettier-ignore
-      prettier: `${prettierCommand} \"**/*.{${getFileTypes(options.formatAllAngularFiles)}}\"`
-    });
-    return tree;
-  };
+	return (tree: Tree, context: SchematicContext) => {
+		addPropertyToPackageJson(tree, context, 'scripts', {
+			// run against all typescript files
+			// prettier-ignore
+			prettier: `${prettierCommand} \"**/*.{${getFileTypes(options.formatAllAngularFiles)}}\"`,
+		});
+		return tree;
+	};
 }
 
 function getFileTypes(allAngularFiles: boolean) {
-  // https://prettier.io/docs/en/options.html#parser
-  // https://prettier.io/blog/2018/11/07/1.15.0.html#automatic-parser-inference
-  return allAngularFiles ? 'js,json,css,scss,less,md,ts,html,component.html' : 'ts,tsx';
+	// https://prettier.io/docs/en/options.html#parser
+	// https://prettier.io/blog/2018/11/07/1.15.0.html#automatic-parser-inference
+	return allAngularFiles ? 'js,json,css,scss,less,md,ts,html,component.html' : 'ts,tsx';
 }

--- a/src/prettier/index.ts
+++ b/src/prettier/index.ts
@@ -1,13 +1,13 @@
 import {
-	Rule,
-	SchematicContext,
-	Tree,
-	chain,
-	apply,
-	url,
-	template,
-	move,
-	mergeWith,
+  Rule,
+  SchematicContext,
+  Tree,
+  chain,
+  apply,
+  url,
+  template,
+  move,
+  mergeWith,
 } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { Observable, of } from 'rxjs';
@@ -16,169 +16,169 @@ import { map, concatMap, filter } from 'rxjs/operators';
 import { PrettierOptions, getDefaultOptions, PrettierSettings } from '../utility/prettier-util';
 import { addPackageJsonDependency, NodeDependencyType } from '../utility/dependencies';
 import {
-	getLatestNodeVersion,
-	NpmRegistryPackage,
-	getFileAsJson,
-	addPropertyToPackageJson,
+  getLatestNodeVersion,
+  NpmRegistryPackage,
+  getFileAsJson,
+  addPropertyToPackageJson,
 } from '../utility/util';
 import { JsonObject } from '@angular-devkit/core';
 
 export default function (options: PrettierOptions): Rule {
-	return (tree: Tree, context: SchematicContext) => {
-		const cliOptions = getDefaultOptions(context, options, new PrettierSettings());
+  return (tree: Tree, context: SchematicContext) => {
+    const cliOptions = getDefaultOptions(context, options, new PrettierSettings());
 
-		return chain([
-			addDependencies(cliOptions),
-			addPrettierFiles(cliOptions),
-			installPackages(),
-			modifyTsLint(),
-			updateEditorConfig(cliOptions),
-			addLintStagedConfig(cliOptions),
-			addScripts(cliOptions),
-		])(tree, context);
-	};
+    return chain([
+      addDependencies(cliOptions),
+      addPrettierFiles(cliOptions),
+      installPackages(),
+      modifyTsLint(),
+      updateEditorConfig(cliOptions),
+      addLintStagedConfig(cliOptions),
+      addScripts(cliOptions),
+    ])(tree, context);
+  };
 }
 
 const prettierCommand = 'prettier --write';
 const tslintConfigPackage = 'tslint-config-prettier';
 
 function addDependencies(options: PrettierOptions): Rule {
-	return (tree: Tree): Observable<Tree> => {
-		const lintStagedDep = ['lint-staged', 'husky'];
+  return (tree: Tree): Observable<Tree> => {
+    const lintStagedDep = ['lint-staged', 'husky'];
 
-		return of('prettier', 'lint-staged', 'husky', tslintConfigPackage).pipe(
-			filter((pkg) => {
-				if (options.lintStaged === false) {
-					// remove lint-staged deps
-					return !lintStagedDep.some((p) => p === pkg);
-				}
-				return true;
-			}),
-			concatMap((pkg: string) => getLatestNodeVersion(pkg)),
-			map((packageFromRegistry: NpmRegistryPackage) => {
-				const { name, version } = packageFromRegistry;
+    return of('prettier', 'lint-staged', 'husky', tslintConfigPackage).pipe(
+      filter((pkg) => {
+        if (options.lintStaged === false) {
+          // remove lint-staged deps
+          return !lintStagedDep.some((p) => p === pkg);
+        }
+        return true;
+      }),
+      concatMap((pkg: string) => getLatestNodeVersion(pkg)),
+      map((packageFromRegistry: NpmRegistryPackage) => {
+        const { name, version } = packageFromRegistry;
 
-				addPackageJsonDependency(tree, { type: NodeDependencyType.Dev, name, version });
+        addPackageJsonDependency(tree, { type: NodeDependencyType.Dev, name, version });
 
-				return tree;
-			})
-		);
-	};
+        return tree;
+      })
+    );
+  };
 }
 
 function installPackages(): Rule {
-	return (tree: Tree, context: SchematicContext): Tree => {
-		return context.addTask(new NodePackageInstallTask()) && tree;
-	};
+  return (tree: Tree, context: SchematicContext): Tree => {
+    return context.addTask(new NodePackageInstallTask()) && tree;
+  };
 }
 
 function addPrettierFiles(prettierOptions: PrettierOptions): Rule {
-	return (tree: Tree, context: SchematicContext) => {
-		const templateSource = apply(url('./files'), [
-			template({
-				...prettierOptions,
-			}),
-			move('./'),
-		]);
+  return (tree: Tree, context: SchematicContext) => {
+    const templateSource = apply(url('./files'), [
+      template({
+        ...prettierOptions,
+      }),
+      move('./'),
+    ]);
 
-		return chain([mergeWith(templateSource)])(tree, context);
-	};
+    return chain([mergeWith(templateSource)])(tree, context);
+  };
 }
 
 function modifyTsLint(): Rule {
-	return (tree: Tree, context: SchematicContext) => {
-		const tslintPath = 'tslint.json';
-		if (tree.exists(tslintPath)) {
-			const tslint = getFileAsJson(tree, tslintPath) as JsonObject;
+  return (tree: Tree, context: SchematicContext) => {
+    const tslintPath = 'tslint.json';
+    if (tree.exists(tslintPath)) {
+      const tslint = getFileAsJson(tree, tslintPath) as JsonObject;
 
-			if (!tslint) return tree;
+      if (!tslint) return tree;
 
-			if (Array.isArray(tslint.extends)) {
-				// should be added last https://github.com/prettier/tslint-config-prettier
-				tslint.extends.push(tslintConfigPackage);
-			} else if (typeof tslint.extends === 'string') {
-				tslint.extends = [tslint.extends, tslintConfigPackage];
-			} else {
-				tslint.extends = tslintConfigPackage;
-			}
+      if (Array.isArray(tslint.extends)) {
+        // should be added last https://github.com/prettier/tslint-config-prettier
+        tslint.extends.push(tslintConfigPackage);
+      } else if (typeof tslint.extends === 'string') {
+        tslint.extends = [tslint.extends, tslintConfigPackage];
+      } else {
+        tslint.extends = tslintConfigPackage;
+      }
 
-			tree.overwrite(tslintPath, JSON.stringify(tslint, null, 2));
-		} else {
-			context.logger.info(
-				`unable to locate tslint file at ${tslintPath}, conflicting styles may exists`
-			);
-		}
+      tree.overwrite(tslintPath, JSON.stringify(tslint, null, 2));
+    } else {
+      context.logger.info(
+        `unable to locate tslint file at ${tslintPath}, conflicting styles may exists`
+      );
+    }
 
-		return tree;
-	};
+    return tree;
+  };
 }
 
 function updateEditorConfig(options: PrettierOptions): Rule {
-	return (tree: Tree, context: SchematicContext) => {
-		const editorConfigPath = '.editorconfig';
-		const rule = 'indent_size';
+  return (tree: Tree, context: SchematicContext) => {
+    const editorConfigPath = '.editorconfig';
+    const rule = 'indent_size';
 
-		if (tree.exists(editorConfigPath)) {
-			// editorconfig exists on host
-			const editorConfigBuffer = tree.read(editorConfigPath);
+    if (tree.exists(editorConfigPath)) {
+      // editorconfig exists on host
+      const editorConfigBuffer = tree.read(editorConfigPath);
 
-			if (editorConfigBuffer === null) {
-				// unable to read editorconfig
-				context.logger.info(
-					`Could not modify .editorconfig at ${editorConfigPath}. Update ${rule} to match tabWidth: ${options.tabWidth}.`
-				);
-			} else {
-				// editorconfig parsed, modify
-				const ecBuffer = editorConfigBuffer.toString();
+      if (editorConfigBuffer === null) {
+        // unable to read editorconfig
+        context.logger.info(
+          `Could not modify .editorconfig at ${editorConfigPath}. Update ${rule} to match tabWidth: ${options.tabWidth}.`
+        );
+      } else {
+        // editorconfig parsed, modify
+        const ecBuffer = editorConfigBuffer.toString();
 
-				if (ecBuffer.includes(rule)) {
-					const modifiedEditorConfig = ecBuffer
-						.split('\n')
-						.map((line) => {
-							if (line.includes(rule)) {
-								return `indent_size = ${options.tabWidth}`;
-							} else {
-								return line;
-							}
-						})
-						.join('\n');
+        if (ecBuffer.includes(rule)) {
+          const modifiedEditorConfig = ecBuffer
+            .split('\n')
+            .map((line) => {
+              if (line.includes(rule)) {
+                return `indent_size = ${options.tabWidth}`;
+              } else {
+                return line;
+              }
+            })
+            .join('\n');
 
-					tree.overwrite(editorConfigPath, modifiedEditorConfig);
-				}
-			}
-		}
-		return tree;
-	};
+          tree.overwrite(editorConfigPath, modifiedEditorConfig);
+        }
+      }
+    }
+    return tree;
+  };
 }
 
 function addLintStagedConfig(options: PrettierOptions) {
-	return (tree: Tree, context: SchematicContext) => {
-		if (options.lintStaged === true) {
-			addPropertyToPackageJson(tree, context, 'husky', {
-				hooks: { 'pre-commit': 'lint-staged' },
-			});
+  return (tree: Tree, context: SchematicContext) => {
+    if (options.lintStaged === true) {
+      addPropertyToPackageJson(tree, context, 'husky', {
+        hooks: { 'pre-commit': 'lint-staged' },
+      });
 
-			addPropertyToPackageJson(tree, context, 'lint-staged', {
-				[`*.{${getFileTypes(options.formatAllAngularFiles)}}`]: [prettierCommand],
-			});
-		}
-		return tree;
-	};
+      addPropertyToPackageJson(tree, context, 'lint-staged', {
+        [`*.{${getFileTypes(options.formatAllAngularFiles)}}`]: [prettierCommand],
+      });
+    }
+    return tree;
+  };
 }
 
 function addScripts(options: PrettierOptions) {
-	return (tree: Tree, context: SchematicContext) => {
-		addPropertyToPackageJson(tree, context, 'scripts', {
-			// run against all typescript files
-			// prettier-ignore
-			prettier: `${prettierCommand} \"**/*.{${getFileTypes(options.formatAllAngularFiles)}}\"`,
-		});
-		return tree;
-	};
+  return (tree: Tree, context: SchematicContext) => {
+    addPropertyToPackageJson(tree, context, 'scripts', {
+      // run against all typescript files
+      // prettier-ignore
+      prettier: `${prettierCommand} \"**/*.{${getFileTypes(options.formatAllAngularFiles)}}\"`,
+    });
+    return tree;
+  };
 }
 
 function getFileTypes(allAngularFiles: boolean) {
-	// https://prettier.io/docs/en/options.html#parser
-	// https://prettier.io/blog/2018/11/07/1.15.0.html#automatic-parser-inference
-	return allAngularFiles ? 'js,json,css,scss,less,md,ts,html,component.html' : 'ts,tsx';
+  // https://prettier.io/docs/en/options.html#parser
+  // https://prettier.io/blog/2018/11/07/1.15.0.html#automatic-parser-inference
+  return allAngularFiles ? 'js,json,css,scss,less,md,ts,html,component.html' : 'ts,tsx';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,6 +213,11 @@ ansi-align@^3.0.0:
   dependencies:
     string-width "^3.0.0"
 
+ansi-colors@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
@@ -222,7 +227,7 @@ ansi-escapes@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-escapes@^4.2.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
   integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
@@ -260,7 +265,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -316,6 +321,11 @@ arrify@^1.0.1:
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async-exit-hook@^2.0.1:
   version "2.0.1"
@@ -561,6 +571,14 @@ cli-truncate@^0.2.1:
     slice-ansi "0.0.4"
     string-width "^1.0.1"
 
+cli-truncate@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
+  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
+  dependencies:
+    slice-ansi "^3.0.0"
+    string-width "^4.2.0"
+
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
@@ -618,6 +636,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
+  integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
+
 commitizen@^4.0.3, commitizen@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/commitizen/-/commitizen-4.2.2.tgz#1a93dd07208521ea1ebbf832593542dac714cc79"
@@ -637,6 +660,11 @@ commitizen@^4.0.3, commitizen@^4.2.2:
     minimist "1.2.5"
     strip-bom "4.0.0"
     strip-json-comments "3.0.1"
+
+compare-versions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -727,6 +755,13 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
+debug@^4.2.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -758,7 +793,7 @@ decompress-response@^5.0.0:
   dependencies:
     mimic-response "^2.0.0"
 
-dedent@0.7.0:
+dedent@0.7.0, dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
@@ -874,6 +909,13 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+enquirer@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  dependencies:
+    ansi-colors "^4.1.1"
 
 error-ex@^1.3.1:
   version "1.3.1"
@@ -1029,7 +1071,7 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-figures@^3.0.0:
+figures@^3.0.0, figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -1081,6 +1123,13 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+find-versions@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
+  integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
+  dependencies:
+    semver-regex "^2.0.0"
+
 findup-sync@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
@@ -1124,6 +1173,11 @@ function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
+  integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
 
 get-stream@^4.1.0:
   version "4.1.0"
@@ -1355,6 +1409,22 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
+husky@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.0.tgz#0b2ec1d66424e9219d359e26a51c58ec5278f0de"
+  integrity sha512-tTMeLCLqSBqnflBZnlVDhpaIMucSGaYyX6855jM4AguGeWCeSzNdb1mfyWduTZ3pe3SJVvVWGL0jO1iKZVPfTA==
+  dependencies:
+    chalk "^4.0.0"
+    ci-info "^2.0.0"
+    compare-versions "^3.6.0"
+    cosmiconfig "^7.0.0"
+    find-versions "^3.2.0"
+    opencollective-postinstall "^2.0.2"
+    pkg-dir "^4.2.0"
+    please-upgrade-node "^3.2.0"
+    slash "^3.0.0"
+    which-pm-runs "^1.0.0"
 
 iconv-lite@^0.4.24:
   version "0.4.24"
@@ -1630,6 +1700,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
 is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
@@ -1677,6 +1752,11 @@ is-regex@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-scoped@^2.1.0:
   version "2.1.0"
@@ -1858,6 +1938,27 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+lint-staged@^10.5.2:
+  version "10.5.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.5.2.tgz#acfaa0093af3262aee3130b2e22438941530bdd1"
+  integrity sha512-e8AYR1TDlzwB8VVd38Xu2lXDZf6BcshVqKVuBQThDJRaJLobqKnpbm4dkwJ2puypQNbLr9KF/9mfA649mAGvjA==
+  dependencies:
+    chalk "^4.1.0"
+    cli-truncate "^2.1.0"
+    commander "^6.2.0"
+    cosmiconfig "^7.0.0"
+    debug "^4.2.0"
+    dedent "^0.7.0"
+    enquirer "^2.3.6"
+    execa "^4.1.0"
+    listr2 "^3.2.2"
+    log-symbols "^4.0.0"
+    micromatch "^4.0.2"
+    normalize-path "^3.0.0"
+    please-upgrade-node "^3.2.0"
+    string-argv "0.3.1"
+    stringify-object "^3.3.0"
+
 listr-input@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/listr-input/-/listr-input-0.2.1.tgz#ce735c34530683580388fdf9462ecfebd3b66126"
@@ -1895,6 +1996,20 @@ listr-verbose-renderer@^0.5.0:
     cli-cursor "^2.1.0"
     date-fns "^1.27.2"
     figures "^2.0.0"
+
+listr2@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.2.3.tgz#ef9e0d790862f038dde8a9837be552b1adfd1c07"
+  integrity sha512-vUb80S2dSUi8YxXahO8/I/s29GqnOL8ozgHVLjfWQXa03BNEeS1TpBLjh2ruaqq5ufx46BRGvfymdBSuoXET5w==
+  dependencies:
+    chalk "^4.1.0"
+    cli-truncate "^2.1.0"
+    figures "^3.2.0"
+    indent-string "^4.0.0"
+    log-update "^4.0.0"
+    p-map "^4.0.0"
+    rxjs "^6.6.3"
+    through "^2.3.8"
 
 listr@^0.14.3:
   version "0.14.3"
@@ -1969,6 +2084,16 @@ log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
+
+log-update@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
+  dependencies:
+    ansi-escapes "^4.3.0"
+    cli-cursor "^3.1.0"
+    slice-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
 
 longest@^2.0.1:
   version "2.0.1"
@@ -2166,6 +2291,11 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -2222,6 +2352,11 @@ normalize-package-data@^3.0.0:
     resolve "^1.17.0"
     semver "^7.3.2"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 normalize-url@^4.1.0:
   version "4.5.0"
@@ -2370,6 +2505,11 @@ open@^7.3.0:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
+
+opencollective-postinstall@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
+  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 ora@5.1.0:
   version "5.1.0"
@@ -2601,6 +2741,13 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
+please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+  dependencies:
+    semver-compare "^1.0.0"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -2609,6 +2756,11 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -2841,12 +2993,22 @@ scoped-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-2.1.0.tgz#7b9be845d81fd9d21d1ec97c61a0b7cf86d2015f"
   integrity sha512-g3WxHrqSWCZHGHlSrF51VXFdjImhwvH8ZO/pryFH56Qi0cDsZfylQa/t0jCzVQFNbNvM00HfHjkDPEuarKDSWQ==
 
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
 semver-diff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-3.1.1.tgz#05f77ce59f325e00e2706afd67bb506ddb1ca32b"
   integrity sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==
   dependencies:
     semver "^6.3.0"
+
+semver-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
+  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.1"
@@ -2927,6 +3089,24 @@ slash@^3.0.0:
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+
+slice-ansi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
+  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -3028,6 +3208,11 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
+string-argv@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -3054,7 +3239,7 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.0.0, string-width@^4.1.0:
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -3070,6 +3255,15 @@ string.prototype.padend@^3.0.0:
     define-properties "^1.1.2"
     es-abstract "^1.4.3"
     function-bind "^1.0.2"
+
+stringify-object@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -3377,6 +3571,11 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
+
 which@^1.2.14, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -3409,6 +3608,15 @@ wrap-ansi@^3.0.1:
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
+
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
- Remove `git add` command. 

[lint-staged](https://github.com/okonet/lint-staged#reformatting-the-code)
> Prior to version 10, tasks had to manually include git add as the final step. This behavior has been integrated into lint-staged itself in order to prevent race conditions with multiple tasks editing the same files. If lint-staged detects git add in task configurations, it will show a warning in the console. Please remove git add from your configuration after upgrading.



- Add Prettier to repo
