### PR TITLE
fix: do not overwrite prettier link in bin folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "angular"
   ],
   "main": "src/prettier/index.js",
-  "bin": "src/prettier/index.js",
   "author": "Kevin Schuchard <schuchard.kevin@gmail.com>",
   "bugs": "https://github.com/schuchard/prettier-schematic/issues",
   "license": "MIT",


### PR DESCRIPTION
Closes: #64 #79